### PR TITLE
Add health check endpoint

### DIFF
--- a/src/main/java/excalibur/quantum/estacionamento/HealthController.java
+++ b/src/main/java/excalibur/quantum/estacionamento/HealthController.java
@@ -1,0 +1,13 @@
+package excalibur.quantum.estacionamento;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class HealthController {
+
+    @GetMapping("/health")
+    public String health() {
+        return "Service running";
+    }
+}

--- a/src/test/java/excalibur/quantum/estacionamento/HealthControllerTest.java
+++ b/src/test/java/excalibur/quantum/estacionamento/HealthControllerTest.java
@@ -1,0 +1,26 @@
+package excalibur.quantum.estacionamento;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class HealthControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void healthEndpointReturnsOk() throws Exception {
+        mockMvc.perform(get("/health"))
+               .andExpect(status().isOk())
+               .andExpect(content().string("Service running"));
+    }
+}


### PR DESCRIPTION
## Summary
- add a simple `/health` endpoint
- provide a basic integration test

## Testing
- `mvnw test -q` *(fails: wget to Maven Central blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6841010afce4832cb67a0b724df414c8